### PR TITLE
Convert body.expires_in into MS

### DIFF
--- a/lib/js/ZCRMRestClient.js
+++ b/lib/js/ZCRMRestClient.js
@@ -315,7 +315,10 @@ ZCRMRestClient.parseAndConstructObject = function(response) {
     // the token will expire on the way to the API and will be rejected. We fix this by subtracting 60 seconds from
     // the expiry time
     const oneMinuteInMs = 1000 * 60;
-    resultObj.expires_in = body.expires_in + current_time - oneMinuteInMs;
+
+    const expires_in_MS = body.expires_in * 1000; // turn 3600s into milliseconds
+
+    resultObj.expires_in = expires_in_MS + current_time - oneMinuteInMs;
   }
   return resultObj;
 };


### PR DESCRIPTION
Bug where the access_token would always be fetched and never actually cached because the expires_in coming from the request was in seconds (3600s) and never converted to Milliseconds, so when the oneMinuteInMs was subtracted it would instantly make expires_in smaller than current_time.